### PR TITLE
Mock SRS and constraints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -584,8 +584,8 @@ mod proof_agg {
                 child_vk_val,
             )?;
 
-            let zero = scalar_chip.assign(&mut layouter, Value::known(F::ZERO))?;
-            let one = scalar_chip.assign(&mut layouter, Value::known(F::ONE))?;
+            let zero = scalar_chip.assign_fixed(&mut layouter, F::ZERO)?;
+            let one = scalar_chip.assign_fixed(&mut layouter, F::ONE)?;
 
             let (out_state_fields, assigned_left_pi_base, assigned_right_pi_base) = if self.is_leaf
             {

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,7 @@ mod proof_agg {
         poly::{EvaluationDomain, kzg::KZGCommitmentScheme},
         transcript::{CircuitTranscript, Transcript},
     };
-    use rand::rngs::OsRng;
+    use rand::{Rng, SeedableRng, rngs::{OsRng, StdRng}};
     use rayon::prelude::*;
     use std::collections::{BTreeMap, BTreeSet};
     use std::env;
@@ -276,7 +276,76 @@ mod proof_agg {
         std::io::Error::new(std::io::ErrorKind::Other, msg.into())
     }
 
-    // TODO test SRS
+    // Deterministic mock SRS for testing only MUST NOT be used in production
+    pub fn mock_srs_agg(k: u32) -> Result<ParamsKZG<Bls12>, std::io::Error> {
+        ensure!(
+            k <= 20,
+            "No Filecoin SRS available for circuits of size k={}",
+            k
+        );
+    
+        let srs_dir = env::var("SRS_DIR").unwrap_or_else(|_| "./examples/assets".into());
+        let srs_path = format!("{srs_dir}/bls_mock_2p{k}");
+        let fetching_path = if Path::new(&srs_path).exists() {
+            srs_path.clone()
+        } else {
+            format!("{srs_dir}/bls_mock_2p20")
+        };
+    
+        // If the (mock) params file we're about to read doesn't exist, create it via unsafe_setup.
+        if !Path::new(&fetching_path).exists() {
+            std::fs::create_dir_all(&srs_dir).map_err(|e| {
+                io_other(format!("Failed to create SRS_DIR '{}': {e}", srs_dir))
+            })?;
+    
+            let rng = StdRng::seed_from_u64(0xDEAD_BEEF_u64);
+    
+            let params = ParamsKZG::<Bls12>::unsafe_setup(20, rng);
+    
+            let mut buf = Vec::new();
+            params
+                .write_custom(&mut buf, SerdeFormat::RawBytesUnchecked)
+                .map_err(|e| io_other(format!("Failed to serialize mock params: {e}")))?;
+    
+            let mut file = File::create(&fetching_path).map_err(|e| {
+                io_other(format!("Failed to create mock SRS file '{}': {e}", fetching_path))
+            })?;
+            file.write_all(&buf)
+                .map_err(|e| io_other(format!("Failed to write mock SRS file '{}': {e}", fetching_path)))?;
+        }
+    
+        let params_fs = File::open(Path::new(&fetching_path)).map_err(|e| {
+            io_other(format!(
+                "Failed to open SRS file at '{}': {e}. (Did you set SRS_DIR?)",
+                fetching_path
+            ))
+        })?;
+    
+        let mut params: ParamsKZG<Bls12> = ParamsKZG::read_custom::<_>(
+            &mut BufReader::new(params_fs),
+            SerdeFormat::RawBytesUnchecked,
+        )
+        .map_err(|e| io_other(format!("Failed to read SRS params from '{}': {e}", fetching_path)))?;
+    
+        // If we loaded the MAX_K file, downsize and cache the per-k file
+        if fetching_path != srs_path {
+            params.downsize(k);
+    
+            let mut buf = Vec::new();
+            params
+                .write_custom(&mut buf, SerdeFormat::RawBytesUnchecked)
+                .map_err(|e| io_other(format!("Failed to serialize downsized params: {e}")))?;
+    
+            let mut file = File::create(&srs_path).map_err(|e| {
+                io_other(format!("Failed to create mock SRS cache file '{}': {e}", srs_path))
+            })?;
+            file.write_all(&buf)
+                .map_err(|e| io_other(format!("Failed to write mock SRS cache '{}': {e}", srs_path)))?;
+        }
+    
+        Ok(params)
+    }
+
     pub fn filecoin_srs_agg(k: u32) -> Result<ParamsKZG<Bls12>, std::io::Error> {
         ensure!(
             k <= 20,


### PR DESCRIPTION
This PR allows the user to use a deterministic mock SRS. It also constrains some constant `AssignedCell`s to actually be constant.